### PR TITLE
Some Improvement and Bugs

### DIFF
--- a/include/spline.hpp
+++ b/include/spline.hpp
@@ -148,6 +148,8 @@ public:
         make_bins();
     }
 
+    cubic_spline(){}
+
     /*
      * Evaluates the cubic splines at `t`.
      */

--- a/include/spline.hpp
+++ b/include/spline.hpp
@@ -164,7 +164,7 @@ public:
         return value;
     }
 
-private:
+public:
     /*
      * Constructs spline segments `_splines` for given set of knot points.
      */
@@ -339,7 +339,14 @@ private:
         }
         std::size_t index = _bins[bin];
 
-        assert(t >= _splines[index].knot);
+        //        assert(t >= _splines[index].knot);
+        int64_t tindex = index;
+        for (; tindex - 1 >= 0; tindex--) {
+            if (t >= _splines[tindex - 1].knot) {
+                break;
+            }
+        }
+        index = tindex;
 
         for (; index + 1 < _splines.size(); index++) {
             if (t < _splines[index + 1].knot) {


### PR DESCRIPTION
1. Let `make_spline` and `make_bins` functions public, since the constructor with parameters is not handy in some scenario. Create a default contructor.
2. fix some logic bugs: replace the assertion with a proper search logic. Sometimes the find_spline logic may crash the library.